### PR TITLE
Make music is default audio stream work for lollipop

### DIFF
--- a/VolumeSteps/src/main/java/com/p1ngu1n/volumesteps/AudioMod.java
+++ b/VolumeSteps/src/main/java/com/p1ngu1n/volumesteps/AudioMod.java
@@ -127,8 +127,11 @@ public class AudioMod implements IXposedHookZygoteInit {
             XposedHelpers.findAndHookMethod(audioServiceClass, "getActiveStreamType", int.class, new XC_MethodHook() {
                 @Override
                 protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                    boolean voiceCapable = XposedHelpers.getBooleanField(param.thisObject, "mVoiceCapable");
-                    if (!voiceCapable) return;
+                    //mVoiceCapable is no longer available in Lollipop
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+                        boolean voiceCapable = XposedHelpers.getBooleanField(param.thisObject, "mVoiceCapable");
+                        if (!voiceCapable) return;
+                    }
 
                     boolean isInCommunication = (Boolean) XposedHelpers.callMethod(param.thisObject, "isInCommunication");
                     if (isInCommunication) return;


### PR DESCRIPTION
Only checks for mVoiceCapable if the Android version is KITKAT or older, because since Lollipop mVoiceCapable is not available anymore.
